### PR TITLE
MAINT: make Incremental example quick on binder

### DIFF
--- a/machine-learning/incremental.ipynb
+++ b/machine-learning/incremental.ipynb
@@ -76,10 +76,10 @@
     "from dask_ml.datasets import make_classification\n",
     "\n",
     "\n",
-    "n, d = 1000000, 100\n",
+    "n, d = 100000, 100\n",
     "\n",
     "X, y = make_classification(n_samples=n, n_features=d,\n",
-    "                           chunks=n // 100, flip_y=0.2)\n",
+    "                           chunks=n // 10, flip_y=0.2)\n",
     "X"
    ]
   },
@@ -338,7 +338,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I played with this on binder, and it was slow. I've made some modifications to make it faster and to have the user wait less time. These modifications are

* decreasing number of chunks by factor of 10
* decreasing number of examples by factor of 10