### PR TITLE
Add Dataframe notebooks

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,3 +17,4 @@ dependencies:
     - graphviz
     - dask_xgboost
     - seaborn
+    - git+https://github.com/mrocklin/dask@dataframes-binder

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - distributed==1.22.0
   - numpy
   - pandas
+  - pyarrow==0.9.0
   - scikit-learn
   - matplotlib
   - nbserverproxy

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,9 +1,9 @@
 channels:
   - defaults
 dependencies:
-  - dask==0.18.1
-  - dask-ml==0.6.0
-  - distributed==1.22.0
+  - dask==0.18.2
+  - dask-ml==0.8.0
+  - distributed==1.22.1
   - numpy
   - pandas
   - pyarrow==0.9.0
@@ -17,4 +17,3 @@ dependencies:
     - graphviz
     - dask_xgboost
     - seaborn
-    - git+https://github.com/mrocklin/dask@dataframes-binder

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,6 +1,7 @@
 channels:
   - defaults
 dependencies:
+  - bokeh=0.12
   - dask==0.18.2
   - dask-ml==0.8.0
   - distributed==1.22.1

--- a/dataframes/01-data-access.ipynb
+++ b/dataframes/01-data-access.ipynb
@@ -10,6 +10,31 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/0eEsIA0O1iE?rel=0&amp;controls=0&amp;showinfo=0\" frameborder=\"0\" allowfullscreen></iframe>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.display import HTML\n",
+    "\n",
+    "HTML('<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/0eEsIA0O1iE?rel=0&amp;controls=0&amp;showinfo=0\" frameborder=\"0\" allowfullscreen></iframe>')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -121,7 +146,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can read many of these files with the dask.dataframe.read_csv function"
+    "We can read one file with `pandas.read_csv` or many files with `dask.dataframe.read_csv`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.read_csv('data/2000-01-01.csv')\n",
+    "df.head()"
    ]
   },
   {
@@ -152,6 +189,15 @@
     "## Tuning read_csv\n",
     "\n",
     "The Pandas `read_csv` function has *many* options to help you parse files.  The Dask version uses the Pandas function internally, and so supports many of the same options.  You can use the `?` operator to see the full documentation string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.read_csv?"
    ]
   },
   {
@@ -199,23 +245,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Write to Parquet\n",
     "\n",
-    "Instead, we'll store our data in Parquet, a format that is more efficient for computers to read and write.  \n",
-    "\n",
-    "We'll install the `pyarrow` library to help us read and write from Parquet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install pyarrow"
+    "Instead, we'll store our data in Parquet, a format that is more efficient for computers to read and write."
    ]
   },
   {
@@ -287,6 +329,15 @@
    "metadata": {},
    "source": [
     "Here the difference is not that large, but with larger datasets this can save a great deal of time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Learn more\n",
+    "\n",
+    "http://dask.pydata.org/en/latest/dataframe-create.html"
    ]
   }
  ],

--- a/dataframes/01-data-access.ipynb
+++ b/dataframes/01-data-access.ipynb
@@ -112,7 +112,7 @@
    "source": [
     "## Read CSV files\n",
     "\n",
-    "We now have many CSV files in our data directory.  Each of them holds some timeseries data."
+    "We now have many CSV files in our data directory, one for each day in the month of January 2000.  Each CSV file holds timeseries data for that day.  We can read all of them as one logical dataframe using the `dd.read_csv` function with a glob string."
    ]
   },
   {

--- a/dataframes/01-data-access.ipynb
+++ b/dataframes/01-data-access.ipynb
@@ -4,12 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# DataFrames: Read and Store Data\n",
-    "\n",
-    "<img src=\"../.images/dask-dataframe.svg\" \n",
-    "     align=\"right\"\n",
-    "     width=\"20%\"\n",
-    "     alt=\"Dask dataframes are blocked Pandas dataframes\">\n",
+    "# DataFrames: Read and Write Data\n",
     "     \n",
     "Dask Dataframes can read and store data in many of the same formats as Pandas dataframes.  In this example we read and write data with the popular CSV and Parquet formats, and discuss best practices when using these formats."
    ]
@@ -18,7 +13,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create local Dask Cluster"
+    "## Start Dask Client for Dashboard\n",
+    "\n",
+    "Starting the Dask Client is optional.  It will provide a dashboard which \n",
+    "is useful to gain insight on the computation.  \n",
+    "\n",
+    "The link to the dashboard will become visible when you create the client below.  We recommend having it open on one side of your screen while using your notebook on the other side.  This can take some effort to arrange your windows, but seeing them both at the same is very useful when learning."
    ]
   },
   {
@@ -49,10 +49,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import dask.dataframe as dd\n",
-    "\n",
-    "df = dd.demo.make_timeseries(start='2000-01-01', end='2000-01-31', freq='1s', partition_freq='1d',\n",
-    "                             dtypes={'name': str, 'id': int, 'x': float, 'y': float})\n",
+    "import dask\n",
+    "df = dask.datasets.timeseries()\n",
     "df"
    ]
   },

--- a/dataframes/02-groupby.ipynb
+++ b/dataframes/02-groupby.ipynb
@@ -128,7 +128,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is the same as with Pandas.  Generally speaking, Dask.dataframe groupby-aggregations are roughly same performance as Pandas groupby-aggregations, just scalable.\n",
+    "This is the same as with Pandas.  Generally speaking, Dask.dataframe groupby-aggregations are roughly same performance as Pandas groupby-aggregations, just more scalable.\n",
+    "\n",
+    "You can read more about Pandas' common aggregations in [the Pandas documentation](https://pandas.pydata.org/pandas-docs/stable/groupby.html#aggregation).\n",
     "\n"
    ]
   },

--- a/dataframes/02-groupby.ipynb
+++ b/dataframes/02-groupby.ipynb
@@ -1,0 +1,224 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DataFrames: Groupby\n",
+    "\n",
+    "This notebook uses the Pandas groupby-aggregate and groupby-apply on scalable Dask dataframes.  It will discuss both common use and best practices."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Start Dask Client for Dashboard\n",
+    "\n",
+    "Starting the Dask Client is optional.  It will provide a dashboard which \n",
+    "is useful to gain insight on the computation.  \n",
+    "\n",
+    "The link to the dashboard will become visible when you create the client below.  We recommend having it open on one side of your screen while using your notebook on the other side.  This can take some effort to arrange your windows, but seeing them both at the same is very useful when learning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client\n",
+    "client = Client(n_workers=1, threads_per_worker=4, processes=False, memory_limit='2GB')\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Artifical dataset\n",
+    "\n",
+    "We create an artificial timeseries dataset to help us work with groupby operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask\n",
+    "df = dask.datasets.timeseries()\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This dataset is small enough to fit in memory, so we persist it now.\n",
+    "\n",
+    "You would skip this step if your dataset becomes too large to fit into memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.persist()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Groupby Aggregations\n",
+    "\n",
+    "Dask dataframes implement a commonly used subset of the Pandas groupby API (see [Pandas Groupby Documentation](https://pandas.pydata.org/pandas-docs/stable/groupby.html).\n",
+    "\n",
+    "We start with groupby aggregations.  These are generally fairly efficient, assuming that the number of groups is small (less than a million)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.groupby('name').x.mean().compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Performance will depend on the aggregation you do (mean vs std), the key on which you group (name vs id), and the number of total groups"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time _ = df.groupby('id').x.mean().compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time _ = df.groupby('name').x.mean().compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time df.groupby('name').agg({'x': ['mean', 'std'], 'y': ['mean', 'count']}).compute().head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the same as with Pandas.  Generally speaking, Dask.dataframe groupby-aggregations are roughly same performance as Pandas groupby-aggregations, just scalable.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Many groups\n",
+    "\n",
+    "By default groupby-aggregations (like groupby-mean or groupby-sum) return the result as a single-partition Dask dataframe.  Their results are *usually* quite small, so this is *usually* a good choice.\n",
+    "\n",
+    "However, sometimes people want to do groupby aggregations on *many* groups (millions or more).  In these cases the full result may not fit into a single Pandas dataframe output, and you may need to split your output into multiple partitions.  You can control this with the `split_out=` parameter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Computational graph of a single output aggregation (for a small number of groups, like 1000)\n",
+    "df.groupby('name').x.mean().visualize(node_attr={'penwidth': '6'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Computational graph of an aggregation to four outputs (for a larger number of groups, like 1000000)\n",
+    "df.groupby('id').x.mean(split_out=4).visualize(node_attr={'penwidth': '6'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Groupby Apply\n",
+    "\n",
+    "Groupby-aggregations are generally quite fast because they can be broken down easily into well known operations.  The data doesn't have to move around too much and we can just pass around small intermediate values across the network.\n",
+    "\n",
+    "For some operations however the function to be applied requires *all* data from a given group (like every record of someone named \"Alice\").  This will force a great deal of communication and be more expensive, but is still possible with the Groupby-apply method.  This should be avoided if a groupby-aggregation works.\n",
+    "\n",
+    "In the following example we train a simple Scikit-Learn machine learning model on every person's name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.linear_model import LinearRegression\n",
+    "\n",
+    "def train(partition):\n",
+    "    est = LinearRegression()\n",
+    "    est.fit(partition[['x', 'id']].values, partition.y.values)\n",
+    "    return est"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time df.groupby('name').apply(train, meta=object).compute().sort_index()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/dataframes/02-groupby.ipynb
+++ b/dataframes/02-groupby.ipynb
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This dataset is small enough to fit in memory, so we persist it now.\n",
+    "This dataset is small enough to fit in the cluster's memory, so we persist it now.\n",
     "\n",
     "You would skip this step if your dataset becomes too large to fit into memory."
    ]

--- a/dataframes/read-csv-and-parquet.ipynb
+++ b/dataframes/read-csv-and-parquet.ipynb
@@ -1,0 +1,316 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DataFrames: Read and Store Data\n",
+    "\n",
+    "<img src=\"../.images/dask-dataframe.svg\" \n",
+    "     align=\"right\"\n",
+    "     width=\"20%\"\n",
+    "     alt=\"Dask dataframes are blocked Pandas dataframes\">\n",
+    "     \n",
+    "Dask Dataframes can read and store data in many of the same formats as Pandas dataframes.  In this example we read and write data with the popular CSV and Parquet formats, and discuss best practices when using these formats."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create local Dask Cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client\n",
+    "client = Client(n_workers=1, threads_per_worker=4, processes=False, memory_limit='2GB')\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create artificial dataset\n",
+    "\n",
+    "First we create an artificial dataset and write it to many CSV files.\n",
+    "\n",
+    "You don't need to understand this section, we're just creating a dataset for the rest of the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.dataframe as dd\n",
+    "\n",
+    "df = dd.demo.make_timeseries(start='2000-01-01', end='2000-01-31', freq='1s', partition_freq='1d',\n",
+    "                             dtypes={'name': str, 'id': int, 'x': float, 'y': float})\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import datetime\n",
+    "\n",
+    "if not os.path.exists('data'):\n",
+    "    os.mkdir('data')\n",
+    "\n",
+    "def name(i):\n",
+    "    \"\"\" Provide date for filename given index\n",
+    "    \n",
+    "    Examples\n",
+    "    --------\n",
+    "    >>> name(0)\n",
+    "    '2000-01-01'\n",
+    "    >>> name(10)\n",
+    "    '2000-01-11'\n",
+    "    \"\"\"\n",
+    "    return str(datetime.date(2000, 1, 1) + i * datetime.timedelta(days=1))\n",
+    "    \n",
+    "df.to_csv('data/*.csv', name_function=name);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read CSV files\n",
+    "\n",
+    "We now have many CSV files in our data directory.  Each of them holds some timeseries data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls data/*.csv | head"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!head data/2000-01-01.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!head data/2000-01-30.csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can read many of these files with the dask.dataframe.read_csv function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask.dataframe as dd\n",
+    "\n",
+    "df = dd.read_csv('data/2000-*-*.csv')\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tuning read_csv\n",
+    "\n",
+    "The Pandas `read_csv` function has *many* options to help you parse files.  The Dask version uses the Pandas function internally, and so supports many of the same options.  You can use the `?` operator to see the full documentation string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dd.read_csv?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case we use the `parse_dates` keyword to parse the timestamp column to be a datetime.  This will make things more efficient in the future.  Notice that the dtype of the timestamp column has changed from `object` to `datetime64[ns]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = dd.read_csv('data/2000-*-*.csv', parse_dates=['timestamp'])\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Do a simple computation\n",
+    "\n",
+    "Whenever we operate on our dataframe we read through all of our CSV data so that we don't fill up RAM.  This is very efficient for memory use, but reading through all of the CSV files every time can be slow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time df.groupby('name').x.mean().compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write to Parquet\n",
+    "\n",
+    "Instead, we'll store our data in Parquet, a format that is more efficient for computers to read and write.  \n",
+    "\n",
+    "We'll install the `pyarrow` library to help us read and write from Parquet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install pyarrow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.to_parquet('data/2000-01.parquet', engine='pyarrow')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls data/2000-01.parquet/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read from Parquet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = dd.read_parquet('data/2000-01.parquet', engine='pyarrow')\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time df.groupby('name').x.mean().compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Select only the columns that you plan to use\n",
+    "\n",
+    "Parquet is a column-store, which means that it can efficiently pull out only a few columns from your dataset.  This is good because it helps to avoid unnecessary data loading."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "df = dd.read_parquet('data/2000-01.parquet', columns=['name', 'x'], engine='pyarrow')\n",
+    "df.groupby('name').x.mean().compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here the difference is not that large, but with larger datasets this can save a great deal of time."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This starts to add a series of notebooks for dask dataframe, similar to what we have now for machine learning.  

I've also included a screencast in the first notebook as an experiment.  If we switch to JupyterLab we could also have this running on the side (if the users right clicks and moves the output to a new cell)

Binder running here: https://mybinder.org/v2/gh/mrocklin/dask-examples/dataframes?filepath=dataframes%2F01-data-access.ipynb

I'm happy to continue going here, but I'd like to get some feedback first if possible, especially from @AlbertDeFusco if he has time.