### PR TITLE
Set num_boost_round

### DIFF
--- a/machine-learning/xgboost.ipynb
+++ b/machine-learning/xgboost.ipynb
@@ -135,11 +135,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "params = {'objective': 'binary:logistic', 'nround': 1000, \n",
+    "params = {'objective': 'binary:logistic',\n",
     "          'max_depth': 4, 'eta': 0.01, 'subsample': 0.5, \n",
     "          'min_child_weight': 0.5}\n",
     "\n",
-    "bst = dask_xgboost.train(client, params, X_train, y_train)"
+    "bst = dask_xgboost.train(client, params, X_train, y_train, num_boost_round=100)"
    ]
   },
   {
@@ -300,7 +300,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We were passing through `nround=1000` to `xgb.train`. AFAICT, that had no effect. Unfortunately, it seems like `xgboost.train` doesn't check for unused kwargs in `param`. 

We want to pass `num_boost_round`, which doesn't go in the `param` dictionary. 1000 took a bit long on my machine, so I set it to 100.

cc @stsievert 