### PR TITLE
Additional ml examples

### DIFF
--- a/machine-learning.ipynb
+++ b/machine-learning.ipynb
@@ -4,16 +4,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Dask for Machine Learning"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Dask integrates well with machine learning libraries like [scikit-learn](http://scikit-learn.org/).\n",
+    "# Dask for Machine Learning\n",
     "\n",
-    "[Dask-ML](http://dask-ml.readthedocs.io/en/latest/index.html) implements scalable machine learning algorithms that are compatible with scikit-learn."
+    "This is a high-level overview demonstrating some the components of Dask-ML.\n",
+    "See [here](./machine-learning) for more details on each individual component."
    ]
   },
   {

--- a/machine-learning/distributed-scikit-learn-for-cpu-bound-problems.ipynb
+++ b/machine-learning/distributed-scikit-learn-for-cpu-bound-problems.ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Distributed Scikit-Learn for CPU Bound Problems\n",
+    "\n",
+    "This example demonstrates how Dask can scale scikit-learn to a cluster of machines for a CPU-bound problem.\n",
+    "We'll fit a large model, a grid-search over many hyper-parameters, on a small dataset.\n",
+    "\n",
+    "This video talks demonstrates the same example on a larger cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "keep_output": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/5Zf6DQaf7jk\" frameborder=\"0\" allow=\"autoplay; encrypted-media\" allowfullscreen> </iframe>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.display import HTML\n",
+    "\n",
+    "HTML(\"\"\"<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/5Zf6DQaf7jk\" frameborder=\"0\" allow=\"autoplay; encrypted-media\" allowfullscreen> </iframe>\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client, progress\n",
+    "client = Client(processes=False, threads_per_worker=4, n_workers=1, memory_limit='2GB')\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "keep_output": true
+   },
+   "source": [
+    "## Distributed Training\n",
+    "\n",
+    "<img src=\".images/scikit-learn-logo-notext.png\"/> <img src=\".images/joblib_logo.svg\" width=\"20%\"/> \n",
+    "\n",
+    "Scikit-learn uses [joblib](http://joblib.readthedocs.io/) for single-machine parallelism. This lets you train most estimators (anything that accepts an `n_jobs` parameter) using all the cores of your laptop or workstation.\n",
+    "\n",
+    "Dask registers a joblib backend. This lets you train those estimators using all the cores of your *cluster*, by changing one line of code.\n",
+    "\n",
+    "This is most useful for training large models on medium-sized datasets. You may have a large model when searching over many hyper-parameters, or when using an ensemble method with many individual estimators. For too small datasets, training times will typically be small enough that cluster-wide parallelism isn't helpful. For too large datasets (larger than a single machine's memory), the scikit-learn estimators may not be able to cope (though Dask-ML provides other ways for working with larger than memory datasets)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask_ml.joblib  # register the distriubted backend\n",
+    "\n",
+    "from pprint import pprint\n",
+    "from time import time\n",
+    "import logging\n",
+    "\n",
+    "from sklearn.datasets import fetch_20newsgroups\n",
+    "from sklearn.feature_extraction.text import CountVectorizer\n",
+    "from sklearn.feature_extraction.text import TfidfTransformer\n",
+    "from sklearn.linear_model import SGDClassifier\n",
+    "from sklearn.model_selection import GridSearchCV\n",
+    "from sklearn.pipeline import Pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Scale Up: set categories=None to use all the categories\n",
+    "categories = [\n",
+    "    'alt.atheism',\n",
+    "    'talk.religion.misc',\n",
+    "]\n",
+    "\n",
+    "print(\"Loading 20 newsgroups dataset for categories:\")\n",
+    "print(categories)\n",
+    "\n",
+    "data = fetch_20newsgroups(subset='train', categories=categories)\n",
+    "print(\"%d documents\" % len(data.filenames))\n",
+    "print(\"%d categories\" % len(data.target_names))\n",
+    "print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll define a small pipeline that combines text feature extraction with a simple classifier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline = Pipeline([\n",
+    "    ('vect', CountVectorizer()),\n",
+    "    ('tfidf', TfidfTransformer()),\n",
+    "    ('clf', SGDClassifier(max_iter=1000)),\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Grid search over some parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parameters = {\n",
+    "    'vect__max_df': (0.5, 0.75, 1.0),\n",
+    "    #'vect__max_features': (None, 5000, 10000, 50000),\n",
+    "    'vect__ngram_range': ((1, 1), (1, 2)),  # unigrams or bigrams\n",
+    "    #'tfidf__use_idf': (True, False),\n",
+    "    #'tfidf__norm': ('l1', 'l2'),\n",
+    "    # 'clf__alpha': (0.00001, 0.000001),\n",
+    "    # 'clf__penalty': ('l2', 'elasticnet'),\n",
+    "    #'clf__n_iter': (10, 50, 80),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid_search = GridSearchCV(pipeline, parameters, n_jobs=-1, verbose=1, cv=3, refit=False, iid=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To fit this normally, we would write\n",
+    "\n",
+    "\n",
+    "```python\n",
+    "grid_search.fit(data.data, data.target)\n",
+    "```\n",
+    "\n",
+    "That would use the default joblib backend (multiple processes) for parallelism.\n",
+    "To use the Dask distributed backend, which will use a cluster of machines to train the model, perform the fit in a `parallel_backend` context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.externals import joblib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with joblib.parallel_backend('dask', scatter=[data.data, data.target]):\n",
+    "    grid_search.fit(data.data, data.target)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you had your distributed dashboard open during that fit, you'll notice that each worker performs some of the fit tasks."
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/machine-learning/distributed-scikit-learn-for-cpu-bound-problems.ipynb
+++ b/machine-learning/distributed-scikit-learn-for-cpu-bound-problems.ipynb
@@ -205,7 +205,6 @@
   }
  ],
  "metadata": {
-  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/machine-learning/parallel-prediction.ipynb
+++ b/machine-learning/parallel-prediction.ipynb
@@ -1,0 +1,185 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parallel and Out-of-core Prediction and Scoring"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sometimes you'll train on a smaller dataset that fits in memory, but need to predict or score for a much larger (possibly larger than memory) dataset. Perhaps your [learning curve](http://scikit-learn.org/stable/modules/learning_curve.html) has leveled off, or you only have labels for a subset of the data.\n",
+    "\n",
+    "In this situation, you can use [`ParallelPostFit`](http://dask-ml.readthedocs.io/en/latest/modules/generated/dask_ml.wrappers.ParallelPostFit.html) to parallelize and distribute the scoring or prediction steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client, progress\n",
+    "\n",
+    "# Scale up: connect to your own cluster with bmore resources\n",
+    "# see http://dask.pydata.org/en/latest/setup.html\n",
+    "client = Client(processes=False, threads_per_worker=4, n_workers=1, memory_limit='2GB')\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import dask.array as da\n",
+    "from sklearn.datasets import make_classification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll generate a small random dataset with scikit-learn."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_train, y_train = make_classification(\n",
+    "    n_features=2, n_redundant=0, n_informative=2,\n",
+    "    random_state=1, n_clusters_per_class=1, n_samples=1000)\n",
+    "X_train[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we'll clone that dataset many times with `dask.array`. `X_large` and `y_large` represent our larger than memory dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Scale up: increase N, the number of times we replicate the data.\n",
+    "N = 100\n",
+    "X_large = da.concatenate([da.from_array(X_train, chunks=X_train.shape)\n",
+    "                          for _ in range(N)])\n",
+    "y_large = da.concatenate([da.from_array(y_train, chunks=y_train.shape)\n",
+    "                          for _ in range(N)])\n",
+    "X_large"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since our training dataset fits in memory, we can use a scikit-learn estimator as the actual estimator fit during traning.\n",
+    "But we know that we'll want to predict for a large dataset, so we'll wrap the scikit-learn estimator with `ParallelPostFit`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.linear_model import LogisticRegressionCV\n",
+    "from dask_ml.wrappers import ParallelPostFit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clf = ParallelPostFit(LogisticRegressionCV(cv=3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll call `clf.fit`. Dask-ML does nothing here, so this step can only use datasets that fit in memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clf.fit(X_train, y_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that training is done, we'll turn to predicting for the full (larger than memory) dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_pred = clf.predict(X_large)\n",
+    "y_pred"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "y_pred is Dask arary. Workers can write the predicted values to a shared file system, without ever having to collect the data on a single machine.\n",
+    "\n",
+    "Or we can check the models score on the entire large dataset. The computation will be done in parallel, and no single machine will have to hold all the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clf.score(X_large, y_large)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/machine-learning/training-on-large-datasets.ipynb
+++ b/machine-learning/training-on-large-datasets.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training on Large Datasets\n",
+    "\n",
+    "Most estimators in scikit-learn are designed to work with NumPy arrays or scipy sparse matricies.\n",
+    "These data structures must fit in the RAM on a single machine.\n",
+    "\n",
+    "Estimators implemented in Dask-ML work well with Dask Arrays and DataFrames. This can be much larger than a single machine's RAM. They can be distributed in memory on a cluster of machines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client\n",
+    "\n",
+    "# Scale up: connect to your own cluster with more resources\n",
+    "# see http://dask.pydata.org/en/latest/setup.html\n",
+    "client = Client(processes=False, threads_per_worker=4, n_workers=1, memory_limit='2GB')\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask_ml.datasets\n",
+    "import dask_ml.cluster\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example, we'll use `dask_ml.datasets.make_blobs` to generate some random *dask* arrays."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Scale up: increase n_samples or n_features\n",
+    "X, y = dask_ml.datasets.make_blobs(n_samples=10000000,\n",
+    "                                   chunks=1000000,\n",
+    "                                   random_state=0,\n",
+    "                                   centers=3)\n",
+    "X = X.persist()\n",
+    "X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll use the k-means implemented in Dask-ML to cluster the points. It uses the `k-means||` (read: \"k-means parallel\") initialization algorithm, which scales better than `k-means++`. All of the computation, both during and after initialization, can be done in parallel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "km = dask_ml.cluster.KMeans(n_clusters=3, init_max_iter=2, oversampling_factor=10)\n",
+    "km.fit(X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll plot a sample of points, colored by the cluster each falls into."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.scatter(X[::10000, 0], X[::10000, 1], marker='.', c=km.labels_[::10000],\n",
+    "           cmap='viridis', alpha=0.25);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For all the estimators implemented in Dask-ML, see the [API documentation](http://dask-ml.readthedocs.io/en/latest/modules/api.html)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This adds dedicated notebooks for CPU bound (distributed scikit-learn) and RAM bound. I've opted to remove the current top-level `machine-learning.ipynb`. I think it can still serve as a nice high-level overview of some of the main features of Dask-ML. I've attempted to link to the `machine-learning` directory from that notebook. It works locally, so hopefully it will on binder as well.

I've also added a parallel prediction notebook.