### PR TITLE
fix to embarassinly parallel notebook

### DIFF
--- a/embarrassingly-parallel.ipynb
+++ b/embarrassingly-parallel.ipynb
@@ -236,7 +236,7 @@
     "import dask\n",
     "lazy_results = []\n",
     "\n",
-    "for parameters in input_params.values[:10]:\n",
+    "for parameters in input_params.values:\n",
     "    lazy_result = dask.delayed(costly_simulation)(parameters)\n",
     "    lazy_results.append(lazy_result)\n",
     "    \n",
@@ -300,7 +300,7 @@
    "source": [
     "%%time\n",
     "futures = []\n",
-    "for parameters in input_params.values[:10]:\n",
+    "for parameters in input_params.values:\n",
     "    future = client.submit(costly_simulation, parameters)\n",
     "    futures.append(future)"
    ]
@@ -327,7 +327,9 @@
    "source": [
     "But the code above can be run in fewer lines with `client.map()` function, allowing to call a given function on a list of parameters.\n",
     "\n",
-    "As for delayed, we can only start the computation and not wait for results by not calling `client.gather()` right now."
+    "As for delayed, we can only start the computation and not wait for results by not calling `client.gather()` right now.\n",
+    "\n",
+    "It shall be noted that as Dask cluster has already performed tasks launching `costly_simulation` with Futures API on the given input parameters, the call to `client.map()` won't actually trigger any computation, and just retrieve already computed results."
    ]
   },
   {
@@ -505,7 +507,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Was trying mybinder, and just run into an issue with this fresh example: we did not run the computation on all inputs despite the documentation saying we were going to do that.
I also noticed that calling `client.map` on the same parameters than `client.submit` before did not trigger any computation.