### PR TITLE
Minor fix in bag.ipynb

### DIFF
--- a/bag.ipynb
+++ b/bag.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!head data/0.json -n 2"
+    "!head -n 2 data/0.json"
    ]
   },
   {


### PR DESCRIPTION
On Mac, the `-n 2` only works before the filename. (on Linux either way works)