### PR TITLE
Update dependency versions in binder environment

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -24,3 +24,4 @@ dependencies:
     - dask_xgboost
     - seaborn
     - mimesis
+    - git+https://github.com/dask/dask@2732793e686dd8e81c967ec54e9fea82b5308226

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - python=3
   - bokeh=1.0.4
-  - dask=1.1.3
+  - dask=1.1.4
   - dask-ml=0.12.0
   - distributed=1.26
   - jupyterlab=0.35.1
@@ -24,4 +24,3 @@ dependencies:
     - dask_xgboost
     - seaborn
     - mimesis
-    - git+https://github.com/dask/dask@2732793e686dd8e81c967ec54e9fea82b5308226

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,7 +4,7 @@ dependencies:
   - python=3
   - bokeh=0.13
   - dask=1.1.2
-  - dask-ml=0.10.0
+  - dask-ml=0.12.0
   - distributed=1.26
   - jupyterlab=0.35.1
   - nodejs=8.9

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3
-  - bokeh=0.13
+  - bokeh=1.0.4
   - dask=1.1.2
   - dask-ml=0.12.0
   - distributed=1.26

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - bokeh=0.13
   - dask=1.1.2
   - dask-ml=0.10.0
-  - distributed=1.24
+  - distributed=1.26
   - jupyterlab=0.35.1
   - nodejs=8.9
   - numpy

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - python=3
   - bokeh=1.0.4
-  - dask=1.1.2
+  - dask=1.1.3
   - dask-ml=0.12.0
   - distributed=1.26
   - jupyterlab=0.35.1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - python=3
   - bokeh=0.13
-  - dask=0.20
+  - dask=1.1.2
   - dask-ml=0.10.0
   - distributed=1.24
   - jupyterlab=0.35.1

--- a/dataframe.ipynb
+++ b/dataframe.ipynb
@@ -138,7 +138,7 @@
    "outputs": [],
    "source": [
     "df2 = df[df.y > 0]\n",
-    "df3 = df2.groupby('name').x.mean()\n",
+    "df3 = df2.groupby('name').x.std()\n",
     "df3"
    ]
   },

--- a/dataframe.ipynb
+++ b/dataframe.ipynb
@@ -138,7 +138,7 @@
    "outputs": [],
    "source": [
     "df2 = df[df.y > 0]\n",
-    "df3 = df2.groupby('name').x.std()\n",
+    "df3 = df2.groupby('name').x.mean()\n",
     "df3"
    ]
   },


### PR DESCRIPTION
The dependency versions in the binder environment file have fallen reasonably out of date. This pull request brings it up to date.

Version upgrades for pinned dependencies:
```
bokeh=0.13        --> bokeh=1.0.4
dask=0.20         --> dask=1.1.4
dask-ml=0.10.0    --> dask-ml=0.12.0
distributed=1.24  -->  distributed=1.26
```

Closes https://github.com/dask/dask-examples/issues/62