### PR TITLE
Bump dask and dask-labextension versions, pin notebook and tornado

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,14 +3,13 @@ channels:
 dependencies:
   - python=3
   - bokeh=1.0.4
-  - dask=1.1.4
+  - dask=1.1.5
   - dask-image=0.2.0
   - dask-ml=0.12.0
-  - distributed=1.26
   - jupyterlab=0.35.4
   - nodejs=8.9
   - notebook<5.7.5
-  - tornado<6
+  - tornado=5
   - numpy
   - pandas
   - pyarrow==0.10.0
@@ -28,5 +27,3 @@ dependencies:
     - dask_xgboost
     - mimesis
     - dask_labextension
-    - git+https://github.com/dask/dask@master
-    - git+https://github.com/dask/distributed@master

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,8 +7,10 @@ dependencies:
   - dask-image=0.2.0
   - dask-ml=0.12.0
   - distributed=1.26
-  - jupyterlab=0.35.1
+  - jupyterlab=0.35.4
   - nodejs=8.9
+  - notebook<5.7.5
+  - tornado<6
   - numpy
   - pandas
   - pyarrow==0.10.0
@@ -25,3 +27,6 @@ dependencies:
   - pip:
     - dask_xgboost
     - mimesis
+    - dask_labextension
+    - git+https://github.com/dask/dask@master
+    - git+https://github.com/dask/distributed@master

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Install the JupyterLab dask-labextension
-jupyter labextension install dask-labextension@0.2
+jupyter labextension install dask-labextension@0.3


### PR DESCRIPTION
We need to figure out the compatibility issues with tornado 6, but in the meantime, this will get things working again.

Fixes #64