### PR TITLE
Bump JupyterLab to 1.0a8.

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -28,5 +28,5 @@ dependencies:
   - pip:
     - dask_xgboost
     - mimesis
-    - jupyterlab==1.0.0a3
-    - dask-labextension==0.3.3
+    - jupyterlab==1.0.0a8
+    - dask-labextension==0.4.0a1

--- a/binder/jupyterlab-workspace.json
+++ b/binder/jupyterlab-workspace.json
@@ -89,6 +89,6 @@
     }
   },
   "metadata": {
-    "id": "WORKSPACE_ID"
+    "id": "/lab"
   }
 }

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Install the JupyterLab dask-labextension
-jupyter labextension install dask-labextension@0.4.0-pre.3
+jupyter labextension install dask-labextension@0.4.0-pre.7

--- a/binder/start
+++ b/binder/start
@@ -2,11 +2,8 @@
 
 # Replace DASK_DASHBOARD_URL with the proxy location
 sed -i -e "s|DASK_DASHBOARD_URL|/user/${JUPYTERHUB_USER}/proxy/8787|g" binder/jupyterlab-workspace.json
-# Get the right workspace ID
-sed -i -e "s|WORKSPACE_ID|/user/${JUPYTERHUB_USER}/lab|g" binder/jupyterlab-workspace.json
 
-# Import the workspace into JupyterLab
-jupyter lab workspaces import binder/jupyterlab-workspace.json \
-  --NotebookApp.base_url=user/${JUPYTERHUB_USER}
+# Temporary workspace workaround
+cp binder/jupyterlab-workspace.json /home/jovyan/.jupyter/lab/workspaces/lab-a511.jupyterlab-workspace
 
 exec "$@"


### PR DESCRIPTION
Fixes #78, fixes #77

Unfortunately, we made a mistake in some of the Javascript semver requirements in publishing the 1.0-prerelease series for JupyterLab, which caused builds of *previous* releases to break.

This brings things up-to-date. There will likely be a bit of churn in the next few days, so I'll try to keep on top of this :/