### PR TITLE
Bump dask-ml version

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - bokeh=1.1.0
   - dask=1.2
   - dask-image=0.2.0
-  - dask-ml=0.13.0
+  - dask-ml=1.0.0
   - nodejs=8.9
   - notebook<5.7.5
   - tornado=5


### PR DESCRIPTION
Dask-ML 1.0 is out, with hyperband

cc @stsievert, so that you have the right version for your hyperband example.