### PR TITLE
Bump to newly-released 1.0 versions.

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - dask=2.0.0
   - dask-image=0.2.0
   - dask-ml=1.0.0
+  - jupyterlab>=1.0
   - nodejs=8.9
   - notebook<5.7.5
   - tornado=5
@@ -28,5 +29,4 @@ dependencies:
   - pip:
     - dask_xgboost
     - mimesis
-    - jupyterlab==1.0.0rc0
-    - dask-labextension==0.4.0a1
+    - dask-labextension>=1.0

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Install the JupyterLab dask-labextension
-jupyter labextension install dask-labextension@1.0.0-rc.0
+jupyter labextension install dask-labextension


### PR DESCRIPTION
Things are calming down a bit now.

This would also be a reasonable time to experiment with the auto-starting cluster for demos. It would look like
1. Creating an initial `LocalCluster` in the dask config
2. Turning on the auto-starting-client option in the JupyterLab settings.