### PR TITLE
Pin JupyterLab to 1.x and add repo2docker CI build

### DIFF
--- a/.github/workflows/ci-repo2docker.yaml
+++ b/.github/workflows/ci-repo2docker.yaml
@@ -1,0 +1,23 @@
+name: repo2docker CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install repo2docker
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install jupyter-repo2docker
+
+      - name: Build dask-examples Docker image
+        run: jupyter-repo2docker --no-run --debug .

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -6,7 +6,10 @@ dependencies:
   - dask=2.9.1
   - dask-image=0.2.0
   - dask-ml=1.2.0
-  - jupyterlab>=1.0
+  # TODO: Bump dask-labextension to >=2 once extensions have been made compatibility updates
+  - dask-labextension=1.1.0
+  # TODO: Bump jupyterlab to 2.x once extensions have been made compatibility updates
+  - jupyterlab=1.*
   - nodejs=8.9
   - notebook<5.7.5
   - tornado=5
@@ -29,4 +32,3 @@ dependencies:
   - dask-xgboost
   - pip:
     - mimesis
-    - dask-labextension>=1.1

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 # Install the JupyterLab dask-labextension
-jupyter labextension install dask-labextension
+# TODO: Unpin dask-labextension version once extensions have been made compatibility updates
+jupyter labextension install dask-labextension@1.1.0


### PR DESCRIPTION
We're temporarily pinning JupyterLab and the dask lab extension to avoid issues with other JL extensions that aren't compatible with JupyterLab 2.0 yet. 

I've also added a GitHub Actions workflow to our CI that runs `repo2docker` on the tutorial to test that binder deployments will work

We did the same thing over in dask-tutorial https://github.com/dask/dask-tutorial/pull/166