### PR TITLE
Update nodejs to 10.15

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - dask-labextension=1.1.0
   # TODO: Bump jupyterlab to 2.x once extensions have been made compatibility updates
   - jupyterlab=1.*
-  - nodejs=8.9
+  - nodejs=10.15
   - notebook<5.7.5
   - tornado=5
   - numba


### PR DESCRIPTION
Bump nodejs version to 10.5 as required by the dask extension, the error
reported was:
"""
The engine "node" is incompatible with this module. Expected version ">=10".
Got "8.9.3"
"""