### PR TITLE
Allow linking to sections on index

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -30,5 +30,8 @@ dependencies:
   - requests
   - py-xgboost
   - dask-xgboost
+  # TODO: Remove when pillow>7.1.1 released
+  # https://github.com/python-pillow/Pillow/issues/4509, https://github.com/dask/dask-examples/pull/144
+  - pillow==7.0.0
   - pip:
     - mimesis

--- a/index.rst
+++ b/index.rst
@@ -12,10 +12,11 @@ You can run these examples in a live session here: |Binder|
 .. |Binder| image:: https://mybinder.org/badge.svg
    :target: https://mybinder.org/v2/gh/dask/dask-examples/master?urlpath=lab
 
+Basic Examples:
+---------------
 
 .. toctree::
    :maxdepth: 1
-   :caption: Basic Examples:
 
    array
    bag
@@ -25,16 +26,20 @@ You can run these examples in a live session here: |Binder|
    machine-learning
    xarray
 
+Dataframes:
+-----------
+
 .. toctree::
    :maxdepth: 1
-   :caption: Dataframes:
 
    dataframes/01-data-access
    dataframes/02-groupby
 
+Machine Learning:
+-----------------
+
 .. toctree::
    :maxdepth: 1
-   :caption: Machine Learning:
 
    machine-learning/scale-scikit-learn
    machine-learning/parallel-prediction
@@ -49,9 +54,11 @@ You can run these examples in a live session here: |Binder|
    machine-learning/glm
    machine-learning/svd
 
+Applications:
+-------------
+
 .. toctree::
    :maxdepth: 1
-   :caption: Applications:
 
    applications/json-data-on-the-web
    applications/async-await
@@ -63,9 +70,11 @@ You can run these examples in a live session here: |Binder|
    applications/satellite-imagery-geotiff
    applications/stencils-with-numba
 
+User Surveys:
+-------------
+
 .. toctree::
    :maxdepth: 1
-   :caption: User Surveys:
 
    surveys/2019.ipynb
 


### PR DESCRIPTION
**What does this PR implement?**
In Dask-ML, I want to link to the section titled with "Machine learning". This PR allows that, so links like `http://examples.dask.org/#machine-learning` will resolve to the correct section.

**Reference issues/PRs**
This motivation is with https://github.com/dask/dask-ml/pull/642 (which depends on this PR).

