### PR TITLE
Nested toc trees for ML and Applications

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -12,11 +12,9 @@ You can run these examples in a live session here: |Binder|
 .. |Binder| image:: https://mybinder.org/badge.svg
    :target: https://mybinder.org/v2/gh/dask/dask-examples/master?urlpath=lab
 
-Basic Examples:
----------------
-
 .. toctree::
    :maxdepth: 1
+   :caption: Basic Examples
 
    array
    bag
@@ -26,20 +24,16 @@ Basic Examples:
    machine-learning
    xarray
 
-Dataframes:
------------
-
 .. toctree::
    :maxdepth: 1
+   :caption: Dataframes
 
    dataframes/01-data-access
    dataframes/02-groupby
 
-Machine Learning:
------------------
-
 .. toctree::
    :maxdepth: 1
+   :caption: Machine Learning
 
    machine-learning/blockwise-ensemble
    machine-learning/scale-scikit-learn
@@ -55,11 +49,9 @@ Machine Learning:
    machine-learning/glm
    machine-learning/svd
 
-Applications:
--------------
-
 .. toctree::
    :maxdepth: 1
+   :caption: Applications
 
    applications/json-data-on-the-web
    applications/async-await
@@ -72,11 +64,9 @@ Applications:
    applications/stencils-with-numba
    applications/forecasting-with-prophet
 
-User Surveys:
--------------
-
 .. toctree::
    :maxdepth: 1
+   :caption: User Surveys
 
    surveys/2019.ipynb
 


### PR DESCRIPTION
The sidebar on https://examples.dask.org is getting a bit crowded. Moving the ML and Applications examples to their own sub-toctrees helps a bit

index.html:

![Screen Shot 2020-05-06 at 2 31 11 PM](https://user-images.githubusercontent.com/1312546/81220460-f1113000-8fa6-11ea-8a8e-c169f4d3887a.png)

machine-learning/index.html:

![Screen Shot 2020-05-06 at 2 31 14 PM](https://user-images.githubusercontent.com/1312546/81220490-fbcbc500-8fa6-11ea-93f1-8b7d3a7ef0df.png)

It's hard to see, but on the `/machine-learning` page, the ML examples in the toc tree are collapsable. It'd be nice if that dropdown were available on the main page as well, but https://github.com/readthedocs/sphinx_rtd_theme/issues/455 might prevent that. https://stackoverflow.com/a/56402641/1889400 has one potential solution that I want to try out later. We might want to delay merging this till that's been explored, unless people think this is already a sufficient improvement.