### PR TITLE
ROC random classifier is diagonal not horizontal line

### DIFF
--- a/machine-learning/xgboost.ipynb
+++ b/machine-learning/xgboost.ipynb
@@ -262,7 +262,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This Receiver Operating Characteristic (ROC) curve tells how well our classifier is doing. We can tell it's doing well by how far it bends the upper-left. A perfect classifier would be in the upper-left corner, and a random classifier would follow the horizontal line.\n",
+    "This Receiver Operating Characteristic (ROC) curve tells how well our classifier is doing. We can tell it's doing well by how far it bends the upper-left. A perfect classifier would be in the upper-left corner, and a random classifier would follow the diagonal line.\n",
     "\n",
     "The area under this curve is `area = 0.76`. This tells us the probability that our classifier will predict correctly for a randomly chosen instance."
    ]


### PR DESCRIPTION
Noticed a minor documentation mistake while working my way through the documentation

![image](https://user-images.githubusercontent.com/2210044/89851486-e67ebc00-dbcf-11ea-8fae-0422c4e23061.png)

If I am not mistaken, a random classifier should correspond to the _diagonal_ line.