### PR TITLE
Bump GHA setup-miniconda version

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Conda Environment
-        uses: goanpeca/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
           python-version: "3.7"


### PR DESCRIPTION
setup-miniconda v2 fixes some deprecations in GitHub Actions. The project has also been moved to conda-incubator.