### PR TITLE
Reduce build time by 5mins+

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -23,6 +23,17 @@ jobs:
           conda install -q pathlib nbconvert nbformat jupyter_client ipykernel
           pip install nbsphinx dask-sphinx-theme sphinx
 
+      - name: Execute Notebooks
+        shell: bash -l {0}
+        run: |
+          pip install nbmake pytest-xdist
+          pytest \
+            -n=auto \
+            --nbmake \
+            --overwrite \
+            --forked \
+            --ignore machine-learning/torch-prediction.ipynb 
+
       - name: Build
         shell: bash -l {0}
         run: sphinx-build -M html . _build -v

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Execute Notebooks
         shell: bash -l {0}
         run: |
-          pip install nbmake pytest-xdist
+          pip install nbmake==0.1 pytest-xdist
           pytest \
             -n=auto \
             --nbmake \

--- a/conf.py
+++ b/conf.py
@@ -43,8 +43,7 @@ extensions = [
     'nbsphinx',
 ]
 
-nbsphinx_timeout = 600
-nbsphinx_execute = "always"
+nbsphinx_execute = 'never'
 
 nbsphinx_prolog = """
 {% set docname = env.doc2path(env.docname, base=None) %}


### PR DESCRIPTION
Thought I'd test out [nbmake](https://github.com/treebeardtech/nbmake) while learning about Dask.

This change executes nbs in parallel via pytest rather than in serial using nbsphinx.

I've manually checked the built docs locally and they look correctly built.