### PR TITLE
Remove references to deprecated `iid` in SearchCV.

### DIFF
--- a/machine-learning.ipynb
+++ b/machine-learning.ipynb
@@ -93,7 +93,6 @@
     "grid_search = GridSearchCV(SVC(gamma='auto', random_state=0, probability=True),\n",
     "                           param_grid=param_grid,\n",
     "                           return_train_score=False,\n",
-    "                           iid=True,\n",
     "                           cv=3,\n",
     "                           n_jobs=-1)"
    ]

--- a/machine-learning/scale-scikit-learn.ipynb
+++ b/machine-learning/scale-scikit-learn.ipynb
@@ -155,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "grid_search = GridSearchCV(pipeline, parameters, n_jobs=-1, verbose=1, cv=3, refit=False, iid=False)"
+    "grid_search = GridSearchCV(pipeline, parameters, n_jobs=-1, verbose=1, cv=3, refit=False)"
    ]
   },
   {
@@ -247,7 +247,7 @@
     "    'estimator__C': [0.01, 1.0, 10],\n",
     "}\n",
     "\n",
-    "grid_search = GridSearchCV(svc, param_grid, iid=False, cv=3)"
+    "grid_search = GridSearchCV(svc, param_grid, cv=3)"
    ]
   },
   {


### PR DESCRIPTION
Addresses https://github.com/dask/dask-ml/issues/791.

**tl;dr**
`iid` has been deprecated and the updated behavior corresponds to `iid=True`.

**Additional Information**

Please, note that the original values in `machine-learning/scale-scikit-learn.ipynb` were set to `iid=False`. I couldn't think of a way to communicate the change of behavior in a markdown cell in the notebook, because my understanding is that the change doesn't affect the example to a significant enough degree to warrant an actual explanation.

I've also checked the remaining examples, in case some of the other model selection imports, were affected by the `iid` deprecation (since it was done at the `BaseSearchCV` level).

**References:**
- Deprecation warning and explanation of associated behavior: https://github.com/scikit-learn/scikit-learn/pull/9379.
- Actual deprecation: https://github.com/scikit-learn/scikit-learn/pull/13834.

Thanks!