### PR TITLE
Update binder badge image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ They are intended to be educational and give users a start on common workflows.
 They should be easy to run locally if you download this repository.
 They are also available on the cloud by clicking on the link below:
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=lab)
+[![Binder](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=lab)
 [![Build Status](https://github.com/dask/dask-examples/workflows/CI/badge.svg)](https://github.com/dask/dask-examples/actions?query=workflow%3ACI)
 
 Contributing

--- a/conf.py
+++ b/conf.py
@@ -52,7 +52,7 @@ nbsphinx_prolog = """
 
     You can run this notebook in a `live session <https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=lab/tree/{{ docname }}>`_ |Binder| or view it `on Github <https://github.com/dask/dask-examples/blob/main/{{ docname }}>`_.
 
-.. |Binder| image:: https://mybinder.org/badge.svg
+.. |Binder| image:: https://static.mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=lab/tree/{{ docname }}
 """
 

--- a/index.rst
+++ b/index.rst
@@ -9,7 +9,7 @@ particular features or use cases.
 
 You can run these examples in a live session here: |Binder|
 
-.. |Binder| image:: https://mybinder.org/badge.svg
+.. |Binder| image:: https://static.mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=lab
 
 .. toctree::


### PR DESCRIPTION
I noticed we're using an [older version of the binder badge image](https://static.mybinder.org/badge.svg). This PR updates the image we use to the same one [used by mybinder.org today](https://static.mybinder.org/badge_logo.svg).

Note there's an upstream issue about redesigning the mybinder.org badge (xref https://github.com/jupyterhub/mybinder.org-deploy/issues/1147), however I still think it's worth using the same image as mybinder.org today. 