### PR TITLE
Fix broken links in incremental notebook

### DIFF
--- a/machine-learning/incremental.ipynb
+++ b/machine-learning/incremental.ipynb
@@ -16,7 +16,7 @@
     "...\n",
     "```\n",
     "\n",
-    "The Scikit-Learn documentation discusses this approach in more depth in their [user guide](http://scikit-learn.org/stable/modules/scaling_strategies.html).\n",
+    "The Scikit-Learn documentation discusses this approach in more depth in their [user guide](http://scikit-learn.org/stable/computing/scaling_strategies.html).\n",
     "\n",
     "This notebook demonstrates the use of Dask-ML's `Incremental` meta-estimator, which automates the use of Scikit-Learn's `partial_fit` over Dask arrays and dataframes. Scikit-Learn handles all of the computation while Dask handles the data management, loading and moving batches of data as necessary. This allows scaling to large datasets distributed across many machines, or to datasets that do not fit in memory, all with a familiar workflow.\n",
     "\n",
@@ -181,7 +181,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we use `SGDClassifier`, but any estimator that implements the `partial_fit` method will work.  A list of Scikit-Learn models that implement this API is available [here](http://scikit-learn.org/stable/modules/scaling_strategies.html#incremental-learning).\n"
+    "Here we use `SGDClassifier`, but any estimator that implements the `partial_fit` method will work.  A list of Scikit-Learn models that implement this API is available [here](https://scikit-learn.org/stable/computing/scaling_strategies.html#incremental-learning).\n"
    ]
   },
   {
@@ -316,11 +316,18 @@
     "\n",
     "In this notebook we went over using Dask-ML's `Incremental` meta-estimator to automate the process of incremental training with Scikit-Learn estimators that implement the `partial_fit` method.  If you want to learn more about this process you might want to investigate the following documentation:\n",
     "\n",
-    "1.  http://scikit-learn.org/stable/modules/scaling_strategies.html\n",
+    "1.  https://scikit-learn.org/stable/computing/scaling_strategies.html\n",
     "2.  [Dask-ML Incremental API documentation](http://ml.dask.org/modules/generated/dask_ml.wrappers.Incremental.html#dask_ml.wrappers.Incremental)\n",
-    "3.  [List of Scikit-Learn estimators compatible with Dask-ML's Incremental](http://scikit-learn.org/stable/modules/scaling_strategies.html#incremental-learning)\n",
+    "3.  [List of Scikit-Learn estimators compatible with Dask-ML's Incremental](https://scikit-learn.org/stable/computing/scaling_strategies.html#incremental-learning)\n",
     "4. For more info on the train-test split for model evaluation, see [Hyperparameters and Model Validation](https://jakevdp.github.io/PythonDataScienceHandbook/05.03-hyperparameters-and-model-validation.html)."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -339,7 +346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixing broken links to scikit-learn documentation in the /machine-learning/incremental.ipynb notebook.  They may have been previously fixed in response to issue #152, but it looks like they need to be fixed again.

Just in case, I loaded this one notebook in mybinder (https://mybinder.org/v2/gh/sasha-kap/dask-examples/ec4c3cb1010ce4be0924f2aa4435503bc40afd1a) and ran it all the way through.