### PR TITLE
updated library name in forecasting example

### DIFF
--- a/applications/forecasting-with-prophet.ipynb
+++ b/applications/forecasting-with-prophet.ipynb
@@ -112,7 +112,7 @@
    "source": [
     "## Parallel Diagnostics\n",
     "\n",
-    "Prophet includes a `fbprophet.diagnostics.cross_validation` function method, which uses *simulated historical forecasts* to provide some idea of a model's quality.\n",
+    "Prophet includes a `prophet.diagnostics.cross_validation` function method, which uses *simulated historical forecasts* to provide some idea of a model's quality.\n",
     "\n",
     "> This is done by selecting cutoff points in the history, and for each of them fitting the model using data only up to that cutoff point. We can then compare the forecasted values to the actual values.\n",
     "\n",
@@ -142,7 +142,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df_cv = fbprophet.diagnostics.cross_validation(\n",
+    "df_cv = prophet.diagnostics.cross_validation(\n",
     "    m, initial=\"730 days\", period=\"180 days\", horizon=\"365 days\",\n",
     "    parallel=\"dask\"\n",
     ")"
@@ -157,22 +157,16 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "55832a72211c01d8b2b5acbce46042c88e2cb82b85bb66b68c3b6ec1f0badd71"
+  },
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3.8.3 64-bit ('base': conda)",
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": ""
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Minor fix to the diagnostics section in the time series forecasting [example](https://examples.dask.org/applications/forecasting-with-prophet.html#Parallel-Diagnostics) since `fbprophet` [was changed](https://github.com/facebook/prophet/issues/1874#issuecomment-824234449) to `prophet`.