### PR TITLE
 Fix binder badge links in survey analysis notebooks

### DIFF
--- a/surveys/2019.ipynb
+++ b/surveys/2019.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=%2Ftree%2Fsurveys%2F2019.ipynb)\n",
     "\n",
-    "Let us know if you find anything in the data.\n"
+    "Let us know if you find anything in the data.\n",
     "\n",
     "## Highlights\n",
     "\n",

--- a/surveys/2019.ipynb
+++ b/surveys/2019.ipynb
@@ -10,7 +10,11 @@
     "which ran earlier this summer. Thanks to everyone who took the time to fill out the survey!\n",
     "These results help us better understand the Dask community and will guide future development efforts.\n",
     "\n",
-    "Let us know if you find anything in the data.\n",
+    "The raw data, as well as the start of an analysis, can be found in this binder:\n",
+    "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=%2Ftree%2Fsurveys%2F2019.ipynb)\n",
+    "\n",
+    "Let us know if you find anything in the data."
     "\n",
     "## Highlights\n",
     "\n",

--- a/surveys/2019.ipynb
+++ b/surveys/2019.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=%2Ftree%2Fsurveys%2F2019.ipynb)\n",
     "\n",
-    "Let us know if you find anything in the data."
+    "Let us know if you find anything in the data.\n"
     "\n",
     "## Highlights\n",
     "\n",

--- a/surveys/2020.ipynb
+++ b/surveys/2020.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "The raw data, as well as the start of an analysis, can be found in this binder:\n",
     "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?filepath=surveys/2020.ipynb)\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=%2Ftree%2Fsurveys%2F2020.ipynb)\n",
     "\n",
     "Let us know if you find anything in the data.\n",
     "\n",

--- a/surveys/2021.ipynb
+++ b/surveys/2021.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "The raw data, as well as the start of an analysis, can be found in this binder:\n",
     "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?filepath=surveys/2021.ipynb)\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=%2Ftree%2Fsurveys%2F2021.ipynb)\n",
     "\n",
     "Let us know if you find anything in the data."
    ]


### PR DESCRIPTION
Some binder badge links were broken, this PR restores that functionality.

Similar to https://github.com/dask/dask-blog/pull/112, see discussion there for details.

Closes https://github.com/dask/dask-examples/issues/196