### PR TITLE
Skip building json-data-on-the-web.ipynb

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -31,7 +31,7 @@ jobs:
             --nbmake \
             --overwrite \
             --forked \
-            --ignore machine-learning/torch-prediction.ipynb
+            --ignore machine-learning/torch-prediction.ipynb \
             --ignore applications/json-data-on-the-web.ipynb
 
       - name: Build


### PR DESCRIPTION
Closes #195 

It seems the data used in `json-data-on-the-web.ipynb` may have grown to the point where the GitHub Actions environment isn't powerful enough to process it before the timeout. Skipping that check to unblock CI.