### PR TITLE
Minimal update of deps to allow installing on ARM Mac

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,13 +3,13 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - bokeh=2.1.1
+  - bokeh=2.2.3
   - dask=2.20.0
   - dask-image=0.2.0
   - dask-ml=1.6.0
   - dask-labextension=2.0.2
   - jupyterlab=2.1
-  - nodejs=14
+  - nodejs=16
   - numba
   - numpy=1.21
   - pip


### PR DESCRIPTION
This PR updates two of the dependencies in the `environment.yml` so that it is installable on an ARM mac. The previous pins had no ARM mac builds available on conda forge. I chose the oldest version that had an ARM build, to be minimally disruptive.

I am not sure if this is exactly the same issue as https://github.com/dask/dask-examples/issues/173 but is possibly overlapping. 

Also partially addresses updating all deps, as raised in https://github.com/dask/dask-examples/issues/206.