### PR TITLE
Pin distributed

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.8
   - bokeh=2.2.3
   - dask=2.20.0
+  - distributed=2.20.0
   - dask-image=0.2.0
   - dask-ml=1.6.0
   - dask-labextension=2.0.2


### PR DESCRIPTION
There seem to be some CI failures related to `distributed` importing something from `dask` that doesn't exist.

We should get things up to date here with latest versions of Dask, but as a short term fix I'm going to try and lock things down to the old versions that worked.