### PR TITLE
Update `dask` and `distributed` version

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - bokeh=2.2.3
   - dask=2022.1.0
   - dask-image=0.2.0
-  - dask-ml=1.6.0
+  - dask-ml=2022.1.22
   - dask-labextension=2.0.2
   - jupyterlab=2.1
   - nodejs=16

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8
   - bokeh=2.2.3
-  - dask=2.20.0
+  - dask=2022.1.0
   - dask-image=0.2.0
   - dask-ml=1.6.0
   - dask-labextension=2.0.2

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - pyarrow
   - python-graphviz
   - seaborn
-  - scikit-learn=0.23
+  - scikit-learn=1.0
   - matplotlib
   - nbserverproxy
   - nomkl


### PR DESCRIPTION
This updates to a more recent version of `dask` / `distributed` to avoid errors like

```python
 ---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Input In [1], in <cell line: 1>()
----> 1 from distributed import Client
      2 import dask_ml.datasets
      3 import dask_ml.ensemble

File /usr/share/miniconda3/envs/dask-examples/lib/python3.8/site-packages/distributed/__init__.py:3, in <module>
      1 from . import config
      2 from dask.config import config
----> 3 from .actor import Actor, ActorFuture
      4 from .core import connect, rpc
      5 from .deploy import LocalCluster, Adaptive, SpecCluster, SSHCluster

File /usr/share/miniconda3/envs/dask-examples/lib/python3.8/site-packages/distributed/actor.py:6, in <module>
      3 import threading
      4 from queue import Queue
----> 6 from .client import Future, default_client
      7 from .protocol import to_serialize
      8 from .utils import sync

File /usr/share/miniconda3/envs/dask-examples/lib/python3.8/site-packages/distributed/client.py:31, in <module>
     29 from dask.core import flatten, get_dependencies
     30 from dask.optimization import SubgraphCallable
---> 31 from dask.compatibility import apply
     32 from dask.utils import ensure_dict, format_bytes, funcname
     34 from tlz import first, groupby, merge, valmap, keymap, partition_all

ImportError: cannot import name 'apply' from 'dask.compatibility' (/usr/share/miniconda3/envs/dask-examples/lib/python3.8/site-packages/dask/compatibility.py)
ImportError: cannot import name 'apply' from 'dask.compatibility' (/usr/share/miniconda3/envs/dask-examples/lib/python3.8/site-packages/dask/compatibility.py)
```

which are [showing up in CI](https://github.com/dask/dask-examples/runs/6063390720?check_suite_focus=true)