### PR TITLE
Update google analytics id

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -67,7 +67,7 @@ nbsphinx_epilog = """
    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-   ga('create', 'UA-18218874-5', 'auto');
+   ga('create', 'UA-18218894-16', 'auto');
    ga('send', 'pageview');
    </script>
    <!-- End Google Analytics -->

--- a/index.rst
+++ b/index.rst
@@ -82,7 +82,8 @@ You can run these examples in a live session here: |Binder|
    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-   ga('create', 'UA-18218874-5', 'auto');
+   ga('create', 'UA-18218894-16', 'auto');
    ga('send', 'pageview');
    </script>
    <!-- End Google Analytics -->
+


### PR DESCRIPTION
I'm fairly certain dask examples aren't being tracked in Google Analytics, and the google analytics id UA-18218874-5 doesn't appear to be attached to any properties currently being tracked on [analytics.dask.org](analytics.dask.org).

This is a draft because I'm not sure if other pieces need to be updated as well. The snippet from Google Analytics looks a bit different from what's here currently:

```html
<!-- Global site tag (gtag.js) - Google Analytics -->
<script async src="https://www.googletagmanager.com/gtag/js?id=UA-18218894-16"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());

  gtag('config', 'UA-18218894-16');
</script>
```
