### PR TITLE
[WIP] Merge on 6/6 - Update theme for rebranding

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install testing and docs dependencies
         run: |
           mamba install nbconvert nbformat jupyter_client ipykernel nbmake \
-          pytest nbsphinx dask-sphinx-theme>=2 sphinx
+          pytest nbsphinx dask-sphinx-theme>=3.0.0 sphinx
 
       - name: Execute Notebooks
         run: |

--- a/conf.py
+++ b/conf.py
@@ -98,7 +98,9 @@ language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+# Commenting this out for now, if we register dask pygments,
+# then eventually this line can be:
+# pygments_style = "dask"
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
On Monday, June 6th, dask.org will go live with a new design (see https://github.com/dask/community/issues/220). This PR is in preparation for the theme update for `dask-sphinx-theme` and can be merged in *after* https://github.com/dask/dask-sphinx-theme/pull/67 on Monday.

cc @jacobtomlinson @jsignell