### PR TITLE
Escape `dask-sphinx-theme` version with quotes

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install testing and docs dependencies
         run: |
           mamba install nbconvert nbformat jupyter_client ipykernel nbmake \
-          pytest nbsphinx dask-sphinx-theme>=3.0.0 sphinx
+          pytest nbsphinx "dask-sphinx-theme>=3.0.0" sphinx
 
       - name: Execute Notebooks
         run: |

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -39,6 +39,9 @@ jobs:
         run: |
           mamba install nbconvert nbformat jupyter_client ipykernel nbmake \
           pytest nbsphinx "dask-sphinx-theme>=3.0.0" sphinx
+          
+          # for debugging purposes
+          mamba env export | grep -E -v '^prefix:.*$'
 
       - name: Execute Notebooks
         run: |


### PR DESCRIPTION
Noticed that the examples page hadn't been bumped to the new theme yet; think it's because the `dask-sphinx-theme` version isn't being quote-escaped in the `mamba install` command; this PR resolves this.

Will also scan through to see if there are any other places where this is happening.