### PR TITLE
Typo Fix in dataframes/03-from-pandas-to-dask.html

### DIFF
--- a/dataframes/03-from-pandas-to-dask.ipynb
+++ b/dataframes/03-from-pandas-to-dask.ipynb
@@ -28,8 +28,8 @@
     "import dask\n",
     "import dask.dataframe as dd\n",
     "import pandas as pd\n",
-    "print(f'Dask versoin: {dask.__version__}')\n",
-    "print(f'Pandas versoin: {pd.__version__}')"
+    "print(f'Dask version: {dask.__version__}')\n",
+    "print(f'Pandas version: {pd.__version__}')"
    ]
   },
   {


### PR DESCRIPTION
Tiny typo, but spotted that "version" was accidentally "versoin" in example print out