### PR TITLE
Fix typos and spacing issues in Dask array example documentation

### DIFF
--- a/array.ipynb
+++ b/array.ipynb
@@ -22,7 +22,7 @@
     "Starting the Dask Client is optional.  It will provide a dashboard which \n",
     "is useful to gain insight on the computation.  \n",
     "\n",
-    "The link to the dashboard will become visible when you create the client below.  We recommend having it open on one side of your screen while using your notebook on the other side.  This can take some effort to arrange your windows, but seeing them both at the same is very useful when learning."
+    "The link to the dashboard will become visible when you create the client below.  We recommend having it open on one side of your screen while using your notebook on the other side. This may take some effort to arrange your windows, but seeing them both at the same time is very useful when learning."
    ]
   },
   {
@@ -43,7 +43,7 @@
    "source": [
     "## Create Random array\n",
     "\n",
-    "This creates a 10000x10000 array of random numbers, represented as many numpy arrays of size 1000x1000 (or smaller if the array cannot be divided evenly). In this case there are 100 (10x10) numpy arrays of size 1000x1000."
+    "This creates a 10000x10000 array of random numbers, represented as many NumPy arrays of size 1000x1000 (or smaller if the array cannot be divided evenly). In this case there are 100 (10x10) numpy arrays of size 1000x1000."
    ]
   },
   {
@@ -81,7 +81,7 @@
    "source": [
     "Call `.compute()` when you want your result as a NumPy array.\n",
     "\n",
-    "If you started `Client()` above then you may want to watch the status page during computation."
+    "If you started `Client()` above, then you may want to watch the status page during computation."
    ]
   },
   {
@@ -99,7 +99,7 @@
    "source": [
     "## Persist data in memory\n",
     "\n",
-    "If you have the available RAM for your dataset then you can persist data in memory.  \n",
+    "If you have the available RAM for your dataset, then you can persist data in memory.  \n",
     "\n",
     "This allows future computations to be much faster."
    ]
@@ -157,7 +157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fixes several small documentation issues in array.ipynb, including:

1. added missing word (“time”)
2. fixed double spaces after periods
3. added commas after introductory phrases
4. corrected "numpy" → "NumPy" where needed


These changes improve readability and consistency across the documentation.
No functional code has been modified.

Checklist
Updated documentation
No API changes
Notebook opens and renders as expected