### PR TITLE
docs: Fix typos and spacing issues in Dask bag documentation

### DIFF
--- a/bag.ipynb
+++ b/bag.ipynb
@@ -28,21 +28,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'dask'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mModuleNotFoundError\u001b[39m                       Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[4]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mdask\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mdistributed\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m Client, progress\n\u001b[32m      2\u001b[39m client = Client(n_workers=\u001b[32m4\u001b[39m, threads_per_worker=\u001b[32m1\u001b[39m)\n\u001b[32m      3\u001b[39m client\n",
-      "\u001b[31mModuleNotFoundError\u001b[39m: No module named 'dask'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from dask.distributed import Client, progress\n",
     "client = Client(n_workers=4, threads_per_worker=1)\n",
@@ -253,21 +241,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'b' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[5]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m df = \u001b[43mb\u001b[49m.map(flatten).to_dataframe()\n\u001b[32m      2\u001b[39m df.head()\n",
-      "\u001b[31mNameError\u001b[39m: name 'b' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = b.map(flatten).to_dataframe()\n",
     "df.head()"


### PR DESCRIPTION
This PR fixes several small documentation issues in bag.ipynb:

**fixes**
added missing word (“time”), ("footprint")
typo in lets -> let's
Added for more clarity->  For deeply nested data, consider flattening or using Bag first, then convert to DataFrame
user defined -> user-defined 

These changes improve readability and consistency across the documentation.
No functional code has been modified.

**Checklist**
Updated documentation
No API changes
Notebook opens and renders as expected
